### PR TITLE
선생님으로 회원가입 시 role 수정

### DIFF
--- a/src/main/kotlin/com/aimory/model/Teacher.kt
+++ b/src/main/kotlin/com/aimory/model/Teacher.kt
@@ -19,7 +19,7 @@ class Teacher(
     name,
     email,
     password,
-    role = Role.PARENT
+    role = Role.TEACHER
 ) {
     @Column(name = "profile_image_url", nullable = false)
     var profileImageUrl: String? = null

--- a/src/main/kotlin/com/aimory/model/Teacher.kt
+++ b/src/main/kotlin/com/aimory/model/Teacher.kt
@@ -21,7 +21,7 @@ class Teacher(
     password,
     role = Role.TEACHER
 ) {
-    @Column(name = "profile_image_url", nullable = false)
+    @Column(name = "profile_image_url", nullable = true)
     var profileImageUrl: String? = null
         protected set
 }


### PR DESCRIPTION
## 💥 연관된 이슈
* #15 
## 🔨 작업 내용
* 선생님으로 회원가입 시 role 을 PARENT 에서 TEACHER 로 초기화하도록 수정
* 선생님 프로필 이미지 URL 에 null 값 허용하도록 수정