### PR TITLE
JWT Payload 파싱 버그 수정

### DIFF
--- a/src/main/kotlin/com/aimory/security/Jwt.kt
+++ b/src/main/kotlin/com/aimory/security/Jwt.kt
@@ -52,7 +52,7 @@ class Jwt(
             userKey = decodedJWT.getClaim("userKey")?.asLong()
             name = decodedJWT.getClaim("name")?.asString()
             email = decodedJWT.getClaim("email")?.asString()
-            roles = decodedJWT.getClaim("roles")?.asList(String::class.java) as List<String?>
+            roles = decodedJWT.getClaim("role")?.asList(String::class.java) as List<String?>
             iat = decodedJWT.issuedAt
             exp = decodedJWT.expiresAt
         }

--- a/src/main/kotlin/com/aimory/security/JwtAuthentication.kt
+++ b/src/main/kotlin/com/aimory/security/JwtAuthentication.kt
@@ -4,7 +4,7 @@ package com.aimory.security
  * 인증된 사용자
  * */
 class JwtAuthentication(
-    val id: Long?,
-    val name: String?,
-    val email: String?,
+    val id: Long,
+    val name: String,
+    val email: String,
 )

--- a/src/main/kotlin/com/aimory/security/JwtAuthenticationTokenFilter.kt
+++ b/src/main/kotlin/com/aimory/security/JwtAuthenticationTokenFilter.kt
@@ -5,7 +5,6 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.apache.commons.lang3.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.GrantedAuthority
@@ -15,7 +14,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.GenericFilterBean
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
-import java.util.*
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 
@@ -43,8 +41,7 @@ class JwtAuthenticationTokenFilter(
                     val email: String? = claims.email
 
                     val authorities = obtainAuthorities(claims)
-
-                    if (Objects.nonNull(userKey) && StringUtils.isNotEmpty(name) && Objects.nonNull(email)) {
+                    if (userKey != null && !name.isNullOrBlank() && !email.isNullOrBlank()) {
                         val authentication =
                             JwtAuthenticationToken(JwtAuthentication(userKey, name, email), null, authorities)
                         authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
@@ -90,7 +87,7 @@ class JwtAuthenticationTokenFilter(
                 log.error(e.message, e)
             }
         }
-        return token
+        return null
     }
 
     private fun verify(token: String): Jwt.Claims {


### PR DESCRIPTION
## 💥 연관된 이슈
* #28 

## 🔨 작업 내용
* JWT Payload 의 claim 파싱 시 role name 이 일치하도록 수정
* api key 에 토큰 타입(Bearer)이 없거나 일치하지 않을 경우 인증 에러(401) 반환하도록 수정
