### PR TITLE
FEAT(#47): 사진 조회 응답에 원아 이름, 등록 시간 추가 및 정렬 기능 추가

### DIFF
--- a/src/main/kotlin/com/aimory/controller/PhotoController.kt
+++ b/src/main/kotlin/com/aimory/controller/PhotoController.kt
@@ -11,6 +11,7 @@ import com.aimory.exception.InvalidPhotoUploadException
 import com.aimory.security.JwtAuthentication
 import com.aimory.service.PhotoService
 import io.swagger.v3.oas.annotations.Operation
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -45,8 +46,20 @@ class PhotoController(
     @GetMapping("/photos")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "전체 사진 조회 API")
-    fun getAllPhotos(): PhotoListResponse {
-        val photoListDto = photoService.getAllPhotos()
+    fun getAllPhotos(
+        @RequestParam(defaultValue = "createdAt") sortBy: String,
+        @RequestParam(defaultValue = "DESC") sortDirection: String,
+    ): PhotoListResponse {
+        val sort = Sort.by(
+            if (sortDirection.equals("ASC", ignoreCase = true)) {
+                Sort.Direction.ASC
+            } else {
+                Sort.Direction.DESC
+            },
+            sortBy
+        )
+
+        val photoListDto = photoService.getAllPhotos(sort)
         val photoCount = photoListDto.size
         val photoListResponse = photoListDto.map { it.toResponse() }
         return PhotoListResponse(photos = photoListResponse, totalCount = photoCount)
@@ -71,10 +84,21 @@ class PhotoController(
     fun getPhotosByChildId(
         @AuthenticationPrincipal authentication: JwtAuthentication,
         @RequestParam("childId") childId: Long,
+        @RequestParam(defaultValue = "createdAt") sortBy: String,
+        @RequestParam(defaultValue = "DESC") sortDirection: String,
     ): PhotoListResponse {
         val memberId = authentication.id
         val memberRole = authentication.role
-        val photoListDto = photoService.getPhotosByChildId(memberId, memberRole, childId)
+        val sort = Sort.by(
+            if (sortDirection.equals("ASC", ignoreCase = true)) {
+                Sort.Direction.ASC
+            } else {
+                Sort.Direction.DESC
+            },
+            sortBy
+        )
+
+        val photoListDto = photoService.getPhotosByChildId(memberId, memberRole, childId, sort)
         val photoCount = photoListDto.size
         val photoListResponse = photoListDto.map { it.toResponse() }
 

--- a/src/main/kotlin/com/aimory/controller/dto/PhotoResponse.kt
+++ b/src/main/kotlin/com/aimory/controller/dto/PhotoResponse.kt
@@ -6,6 +6,8 @@ data class PhotoResponse(
     val photoId: Long,
     val imageUrl: String,
     val childId: Long,
+    val childName: String,
+    val createdAt: String,
 )
 
 data class PhotoListResponse(
@@ -16,7 +18,9 @@ data class PhotoListResponse(
 fun PhotoResponseDto.toResponse() = PhotoResponse(
     photoId = photoId,
     imageUrl = imageUrl,
-    childId = childId
+    childId = childId,
+    childName = childName,
+    createdAt = createdAt
 )
 
 fun List<PhotoResponseDto>.toResponse(): List<PhotoResponse> {

--- a/src/main/kotlin/com/aimory/model/Photo.kt
+++ b/src/main/kotlin/com/aimory/model/Photo.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "photo")
@@ -22,6 +23,10 @@ class Photo(
 
     @Column(name = "image_url", nullable = false)
     var imageUrl: String = imageUrl
+        protected set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/aimory/repository/PhotoRepository.kt
+++ b/src/main/kotlin/com/aimory/repository/PhotoRepository.kt
@@ -1,6 +1,7 @@
 package com.aimory.repository
 
 import com.aimory.model.Photo
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface PhotoRepository : JpaRepository<Photo, Long> {
 
-    fun findByChildId(childId: Long): List<Photo>
+    fun findByChildId(childId: Long, sort: Sort): List<Photo>
 
     @Query("SELECT p FROM Photo p WHERE p.child.id IN :childIds")
     fun findAllByChildIds(childIds: List<Long>): List<Photo>

--- a/src/main/kotlin/com/aimory/service/PhotoService.kt
+++ b/src/main/kotlin/com/aimory/service/PhotoService.kt
@@ -14,6 +14,7 @@ import com.aimory.repository.PhotoRepository
 import com.aimory.service.dto.PhotoResponseDto
 import com.aimory.service.dto.toResponseDto
 import com.aimory.service.dto.toResponseDtoList
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -40,8 +41,8 @@ class PhotoService(
         return savedPhotos.toResponseDtoList()
     }
 
-    fun getAllPhotos(): List<PhotoResponseDto> {
-        val photos = photoRepository.findAll()
+    fun getAllPhotos(sort: Sort): List<PhotoResponseDto> {
+        val photos = photoRepository.findAll(sort)
         return photos.toResponseDtoList()
     }
 
@@ -54,13 +55,13 @@ class PhotoService(
         return photo.toResponseDto()
     }
 
-    fun getPhotosByChildId(memberId: Long, memberRole: Role, childId: Long): List<PhotoResponseDto> {
+    fun getPhotosByChildId(memberId: Long, memberRole: Role, childId: Long, sort: Sort): List<PhotoResponseDto> {
         val child = childRepository.findById(childId)
             .orElseThrow { ChildNotFoundException() }
 
         checkParentCanAccessChild(memberId, memberRole, child)
 
-        return photoRepository.findByChildId(childId).toResponseDtoList()
+        return photoRepository.findByChildId(childId, sort).toResponseDtoList()
     }
 
     @Transactional

--- a/src/main/kotlin/com/aimory/service/dto/PhotoResponseDto.kt
+++ b/src/main/kotlin/com/aimory/service/dto/PhotoResponseDto.kt
@@ -6,13 +6,18 @@ data class PhotoResponseDto(
     val photoId: Long,
     val imageUrl: String,
     val childId: Long,
+    val childName: String,
+    val createdAt: String,
+
 )
 
 fun Photo.toResponseDto(): PhotoResponseDto {
     return PhotoResponseDto(
         photoId = this.id,
         imageUrl = this.imageUrl,
-        childId = this.child.id
+        childId = this.child.id,
+        childName = this.child.name,
+        createdAt = this.createdAt.toString()
     )
 }
 


### PR DESCRIPTION
## 💥 연관된 이슈
- #47 

## 🔨 작업 내용
사진첩 조회 시 최신순 정렬되도록 sort 추가했습니다.
(사진 전체 조회, 특정 원아 사진 조회에 모두 추가)
사진 추가, 조회 시 원아 이름과 등록 시간 표시되도록 추가했습니다.

## 🙏 리뷰 요구 사항
기존 최신순 정렬 코드와 이상 없이 같은 스타일로 작업 되었는지 확인 부탁 드립니다.
응답에 원아 이름과 등록 시간 표시되도록 수정한 것 확인 부탁 드립니다.
