### PR TITLE
BaseEntity 생성, content 타입 변경

### DIFF
--- a/src/main/kotlin/com/aimory/controller/dto/NoteResponse.kt
+++ b/src/main/kotlin/com/aimory/controller/dto/NoteResponse.kt
@@ -2,6 +2,7 @@ package com.aimory.controller.dto
 
 import com.aimory.service.dto.NoteResponseDto
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class NoteResponse(
     val id: Long,
@@ -11,8 +12,8 @@ data class NoteResponse(
     val image: String?,
     val content: String,
     val date: LocalDate,
-    val createdAt: LocalDate,
-    val updatedAt: LocalDate,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )
 
 data class NoteListResponse(

--- a/src/main/kotlin/com/aimory/controller/dto/NoticeResponse.kt
+++ b/src/main/kotlin/com/aimory/controller/dto/NoticeResponse.kt
@@ -2,6 +2,7 @@ package com.aimory.controller.dto
 
 import com.aimory.service.dto.NoticeResponseDto
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class NoticeResponse(
     val id: Long,
@@ -10,8 +11,8 @@ data class NoticeResponse(
     val title: String,
     val content: String,
     val date: LocalDate,
-    val createdAt: LocalDate,
-    val updatedAt: LocalDate,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )
 
 data class NoticeListResponse(

--- a/src/main/kotlin/com/aimory/model/BaseEntity.kt
+++ b/src/main/kotlin/com/aimory/model/BaseEntity.kt
@@ -1,0 +1,19 @@
+package com.aimory.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import java.time.LocalDateTime
+
+@MappedSuperclass
+class BaseEntity() {
+    @Column(name = "created_at", updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = createdAt
+        protected set
+
+    fun updatedAt() {
+        this.updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/aimory/model/Note.kt
+++ b/src/main/kotlin/com/aimory/model/Note.kt
@@ -21,7 +21,7 @@ class Note(
     date: LocalDate,
     child: Child,
     classroom: Classroom,
-) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
@@ -32,14 +32,6 @@ class Note(
 
     @Column(name = "date", nullable = false)
     var date: LocalDate = date
-        protected set
-
-    @Column(name = "created_at", nullable = false)
-    var createdAt: LocalDate = LocalDate.now()
-        protected set
-
-    @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDate = createdAt
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -64,6 +56,6 @@ class Note(
         this.child = child
         this.content = noteRequestDto.content
         this.date = noteRequestDto.date
-        this.updatedAt = LocalDate.now()
+        updatedAt()
     }
 }

--- a/src/main/kotlin/com/aimory/model/Note.kt
+++ b/src/main/kotlin/com/aimory/model/Note.kt
@@ -26,7 +26,7 @@ class Note(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     var content: String = content
         protected set
 

--- a/src/main/kotlin/com/aimory/model/Notice.kt
+++ b/src/main/kotlin/com/aimory/model/Notice.kt
@@ -21,7 +21,7 @@ class Notice(
     content: String,
     date: LocalDate,
     center: Center,
-) {
+) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
@@ -36,14 +36,6 @@ class Notice(
 
     @Column(name = "date", nullable = false)
     var date: LocalDate = date
-        protected set
-
-    @Column(name = "created_at", nullable = false)
-    var createdAt: LocalDate = LocalDate.now()
-        protected set
-
-    @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDate = createdAt
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -63,6 +55,6 @@ class Notice(
         this.title = noticeRequestDto.title
         this.content = noticeRequestDto.content
         this.date = noticeRequestDto.date
-        this.updatedAt = LocalDate.now()
+        updatedAt()
     }
 }

--- a/src/main/kotlin/com/aimory/model/Notice.kt
+++ b/src/main/kotlin/com/aimory/model/Notice.kt
@@ -30,7 +30,7 @@ class Notice(
     var title: String = title
         protected set
 
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     var content: String = content
         protected set
 

--- a/src/main/kotlin/com/aimory/service/dto/NoteResponseDto.kt
+++ b/src/main/kotlin/com/aimory/service/dto/NoteResponseDto.kt
@@ -2,6 +2,7 @@ package com.aimory.service.dto
 
 import com.aimory.model.Note
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class NoteResponseDto(
     val id: Long,
@@ -11,8 +12,8 @@ data class NoteResponseDto(
     val image: String?,
     val content: String,
     val date: LocalDate,
-    val createdAt: LocalDate,
-    val updatedAt: LocalDate,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )
 
 fun Note.toResponseDto() = NoteResponseDto(

--- a/src/main/kotlin/com/aimory/service/dto/NoticeResponseDto.kt
+++ b/src/main/kotlin/com/aimory/service/dto/NoticeResponseDto.kt
@@ -2,6 +2,7 @@ package com.aimory.service.dto
 
 import com.aimory.model.Notice
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class NoticeResponseDto(
     val id: Long,
@@ -10,8 +11,8 @@ data class NoticeResponseDto(
     val title: String,
     val content: String,
     val date: LocalDate,
-    val createdAt: LocalDate,
-    val updatedAt: LocalDate,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )
 
 fun Notice.toResponseDto() = NoticeResponseDto(


### PR DESCRIPTION
## 💥 연관된 이슈
<!-- 예) #이슈번호 -->
- #52

## 🔨 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요! -->
`createdAt`, `updatedAt` 공통 관리를 위해 `BaseEntity`를 생성했습니다.
또한, 공지사항, 알림장의 `content` 타입을 `TEXT`로 변경하였습니다.

## 🙏 리뷰 요구 사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요! -->
☺️